### PR TITLE
Add a package.json so that this can be published to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "spark",
+  "version": "1.0.0",
+  "description": "Spark - six fonts for creating sparklines",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aftertheflood/spark.git"
+  },
+  "keywords": [
+    "spark",
+    "sparkline",
+    "font"
+  ],
+  "author": "Michael Gallagher",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/aftertheflood/spark/issues"
+  },
+  "homepage": "https://github.com/aftertheflood/spark#readme"
+}


### PR DESCRIPTION
I would like this to be published to NPM.  That would help make this easier to work with in typical tooling workflow.  I can help get that done.  It should be in your name.

The first step is a `package.json`.