### PR TITLE
Fix 404 website link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To quickly include the fonts in your web page you may wish to use our stylesheet
   <link href="https://tools.aftertheflood.com/sparks/styles/font-faces.css" rel="stylesheet" />
 ```
 
-See it working on our [website](http://aftertheflood.com/projects/sparks) or in one of our interactive notebook examples
+See it working on our [website](http://tools.aftertheflood.com/sparks/) or in one of our interactive notebook examples
 
  * <a href="https://beta.observablehq.com/@tomgp/after-the-flood-i-sparks-i-typeface">A simple usage example</a>
  * <a href="https://beta.observablehq.com/@tomgp/sparks-in-an-svg">Using Sparks within an SVG</a>


### PR DESCRIPTION
The `website` link was taking people to a 404. I'm not sure if there's an "official" alternative, but I found `http://tools.aftertheflood.com/sparks/` which felt like the right url. Alternatively, `https://aftertheflood.com/journal/the-worlds-first-code-free-sparkline-typeface/` might be a good backup.